### PR TITLE
use faster typed arrays for monkeyIndexArray allocation

### DIFF
--- a/src/WebMonkeys.js
+++ b/src/WebMonkeys.js
@@ -25,7 +25,7 @@ load(this, function (exports) {
       arrayByName = {};
       shaderByTask = {};
       // monkeyIndexArray = [];
-      monkeyIndexArray = new Uint8Array(maxMonkeys);
+      monkeyIndexArray = new Int32Array(maxMonkeys);
 
       var glOpt = {antialias: false, preserveDrawingBuffer: true};
       if (typeof window === "undefined"){

--- a/src/WebMonkeys.js
+++ b/src/WebMonkeys.js
@@ -24,7 +24,8 @@ load(this, function (exports) {
       arrays = [];
       arrayByName = {};
       shaderByTask = {};
-      monkeyIndexArray = [];
+      // monkeyIndexArray = [];
+      monkeyIndexArray = new Uint8Array(maxMonkeys);
 
       var glOpt = {antialias: false, preserveDrawingBuffer: true};
       if (typeof window === "undefined"){


### PR DESCRIPTION
TypedArrays are anywhere from 10+times faster

Benchmark.

typed array: 16
normal array: 164

ops/s

[https://esbench.com/bench/57c1f350db965b9a00965c94](https://esbench.com/bench/57c1f350db965b9a00965c94)