### PR TITLE
using an ArrayBuffer with TypedArray improves initialisation

### DIFF
--- a/src/WebMonkeys.js
+++ b/src/WebMonkeys.js
@@ -1,11 +1,9 @@
 load(this, function (exports) {
   function WebMonkeys(opt){
-    var maxMonkeys,
-      resultTextureSide,
+    var resultTextureSide,
       arrays,
       arrayByName,
       shaderByTask,
-      monkeyIndexArray,
       gl,
       defaultLib,
       writer,
@@ -19,12 +17,10 @@ load(this, function (exports) {
     // () -> Monkeys
     function init(){
       opt = opt || [];
-      maxMonkeys = opt.maxMonkeys || 2048*2048;
       resultTextureSide = opt.resultTextureSide || 2048;
       arrays = [];
       arrayByName = {};
       shaderByTask = {};
-      monkeyIndexArray = new Int32Array(maxMonkeys);
 
       var glOpt = {antialias: false, preserveDrawingBuffer: true};
       if (typeof window === "undefined"){
@@ -44,8 +40,12 @@ load(this, function (exports) {
           "-ms-interpolation-mode: nearest-neighbor;"].join("");
       }
 
-      for (var i=0; i<maxMonkeys; ++i)
-        monkeyIndexArray[i] = i; 
+      var buffer = new ArrayBuffer((2048*2048)|0);
+      var maxMonkeys = buffer.byteLength|0;
+      var monkeyIndexArray = new Int32Array(buffer);
+
+      for (var i=0|0; i<maxMonkeys; ++i)
+        monkeyIndexArray[i|0] = i|0; 
 
       defaultLib = [
         "vec2 indexToPos(vec2 size, float index){",


### PR DESCRIPTION
using an ArrayBuffer to create monkeyIndexArray -> initialisation 3X++ faster.

```
var buffer = new ArrayBuffer((2048*2048)|0);
var monkeyIndexArray = new Int32Array(buffer);
...
new Float32Array(monkeyIndexArray)
``` 

typed array /w buffer: 38.11500000000001
typed array: 128.70000000000002
normal array: 174.52500000000003

ops/s

[https://esbench.com/bench/57c1f350db965b9a00965c94](https://esbench.com/bench/57c1f350db965b9a00965c94)