### PR TITLE
Increase supported vendors

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -12,9 +12,10 @@
 		// i.e 
 		// https://rawgit.com/MaiaVictor/WebMonkeys/master/examples/index.html?example=squareNumbers.js
 		var example = window.location.search.split('?example=')[1];
+		var source = example ? './'+example : './searchFor987654321.js';
 		var script = document.createElement('script');
 		document.head.appendChild(script);
-		script.src = './'+example;
+		script.src = source;
 	</script>
 </body>
 </html>

--- a/src/WebMonkeys.js
+++ b/src/WebMonkeys.js
@@ -275,7 +275,7 @@ load(this, function (exports) {
           for (var i=0, l=lengthOrArray.length; i<l; ++i){ 
             var x = lengthOrArray[i];
             var s = x > 0 ? 1 : -1;
-            var e = Math.floor(Math.log2(s*x));
+            var e = Math.floor(Math.log(s*x) / Math.LN2);
             var m = s*x/Math.pow(2, e);
             array[i*4+0] = Math.floor(fract((m-1)*256*256)*256)||0;
             array[i*4+1] = Math.floor(fract((m-1)*256)*256)||0;

--- a/src/WebMonkeys.js
+++ b/src/WebMonkeys.js
@@ -29,7 +29,7 @@ load(this, function (exports) {
         gl = require("g"+"l")(1, 1, glOpt);
       } else {
         var canvas = document.createElement("canvas");
-        gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+        gl = canvas.getContext('webgl', glOpt) || canvas.getContext('experimental-webgl', glOpt);
         gl.canvas = canvas;
         gl.canvas.width = 1;
         gl.canvas.height = 1;

--- a/src/WebMonkeys.js
+++ b/src/WebMonkeys.js
@@ -1,11 +1,9 @@
 load(this, function (exports) {
   function WebMonkeys(opt){
-    var maxMonkeys,
-      resultTextureSide,
+    var resultTextureSide,
       arrays,
       arrayByName,
       shaderByTask,
-      monkeyIndexArray,
       gl,
       defaultLib,
       writer,
@@ -19,12 +17,10 @@ load(this, function (exports) {
     // () -> Monkeys
     function init(){
       opt = opt || [];
-      maxMonkeys = opt.maxMonkeys || 2048*2048;
       resultTextureSide = opt.resultTextureSide || 2048;
       arrays = [];
       arrayByName = {};
       shaderByTask = {};
-      monkeyIndexArray = new Int32Array(maxMonkeys);
 
       var glOpt = {antialias: false, preserveDrawingBuffer: true};
       if (typeof window === "undefined"){
@@ -44,8 +40,12 @@ load(this, function (exports) {
           "-ms-interpolation-mode: nearest-neighbor;"].join("");
       }
 
-      for (var i=0; i<maxMonkeys; ++i)
-        monkeyIndexArray[i] = i; 
+      var buffer = new ArrayBuffer((2048*2048)|0);
+      var maxMonkeys = buffer.byteLength|0;
+      var monkeyIndexArray = new Int32Array(buffer);
+
+      for (var i=0|0; i<maxMonkeys; ++i)
+        monkeyIndexArray[i|0] = i|0; 
 
       defaultLib = [
         "vec2 indexToPos(vec2 size, float index){",

--- a/src/WebMonkeys.js
+++ b/src/WebMonkeys.js
@@ -29,7 +29,7 @@ load(this, function (exports) {
         gl = require("g"+"l")(1, 1, glOpt);
       } else {
         var canvas = document.createElement("canvas");
-        gl = canvas.getContext("webgl", glOpt);
+        gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
         gl.canvas = canvas;
         gl.canvas.width = 1;
         gl.canvas.height = 1;

--- a/src/WebMonkeys.js
+++ b/src/WebMonkeys.js
@@ -1,9 +1,11 @@
 load(this, function (exports) {
   function WebMonkeys(opt){
-    var resultTextureSide,
+    var maxMonkeys,
+      resultTextureSide,
       arrays,
       arrayByName,
       shaderByTask,
+      monkeyIndexArray,
       gl,
       defaultLib,
       writer,
@@ -17,10 +19,12 @@ load(this, function (exports) {
     // () -> Monkeys
     function init(){
       opt = opt || [];
+      maxMonkeys = opt.maxMonkeys || 2048*2048;
       resultTextureSide = opt.resultTextureSide || 2048;
       arrays = [];
       arrayByName = {};
       shaderByTask = {};
+      monkeyIndexArray = new Int32Array(maxMonkeys);
 
       var glOpt = {antialias: false, preserveDrawingBuffer: true};
       if (typeof window === "undefined"){
@@ -40,12 +44,8 @@ load(this, function (exports) {
           "-ms-interpolation-mode: nearest-neighbor;"].join("");
       }
 
-      var buffer = new ArrayBuffer((2048*2048)|0);
-      var maxMonkeys = buffer.byteLength|0;
-      var monkeyIndexArray = new Int32Array(buffer);
-
-      for (var i=0|0; i<maxMonkeys; ++i)
-        monkeyIndexArray[i|0] = i|0; 
+      for (var i=0; i<maxMonkeys; ++i)
+        monkeyIndexArray[i] = i; 
 
       defaultLib = [
         "vec2 indexToPos(vec2 size, float index){",


### PR DESCRIPTION
use Math.log2 alternative & experimental-webgl fallback to increase support for IE11 and older safari vendors. Also supply a default example for the examples [index.html](https://rawgit.com/MaiaVictor/WebMonkeys/master/examples/index.html)