### PR TITLE
GPU miners example works now, if slowly.

### DIFF
--- a/examples/minerMonkeys.js
+++ b/examples/minerMonkeys.js
@@ -1,4 +1,4 @@
-if (typeof window === 'object') 
+if (typeof window === 'object')
   var monkeys = WebMonkeys();
 else
   var monkeys = require("./../src/WebMonkeys")();
@@ -21,7 +21,7 @@ function mineSequential(blockhash){
   return 0;
 };
 
-// To do that in parallel, we just spawn tons of monkeys 
+// To do that in parallel, we just spawn tons of monkeys
 // and make them try different nonces at the same time.
 function mineParallel(totalMonkeys, attemptsPerMonkey, blockhash){
 
@@ -35,7 +35,7 @@ function mineParallel(totalMonkeys, attemptsPerMonkey, blockhash){
   // Each monkey attempts a a different set of
   // nonces, so we upload an array determining
   // the start nonce of each monkey.
-  var monkeyNonce = [];  
+  var monkeyNonce = [];
   for (var i = 0; i < totalMonkeys; ++i)
     monkeyNonce.push(i * attemptsPerMonkey);
   monkeys.set("monkeyNonce", monkeyNonce);
@@ -51,7 +51,8 @@ function mineParallel(totalMonkeys, attemptsPerMonkey, blockhash){
     // Do the actual mining work, restricted to the subset
     // of nonces this monkey is responsible for
     float mined = 0.0;
-    for (float nonce = startNonce; nonce < startNonce+attempts; ++nonce){
+    for (float nonce0 = 0.0; nonce0 < attempts; ++nonce0){
+      float nonce = nonce0 + startNonce;
       float hash = mod(bhash * (nonce+1.0), pow(2.0,31.0) - 1.0);
       if (hash >= 0.0 && hash <= 3000.0)
         mined = nonce;
@@ -73,12 +74,17 @@ function mineParallel(totalMonkeys, attemptsPerMonkey, blockhash){
 };
 
 // Mine the block on the CPU
-console.log("Mined a block on the CPU, nonce: "+mineSequential(12345, 5));
+var t = Date.now();
+console.log("Mined a block on the CPU, nonce: " + mineSequential(12345, 5) +
+            " (time: " + (Date.now() - t) / 1000 + "s)");
 
 // Mine the block on the GPU, with 128 monkeys,
 // each one attempting 6000 different nonces,
 // starting at nonce 0.
-console.log("Mined a block on the GPU, nonce: "+mineParallel(128, 6000, 12345));
+t = Date.now();
+console.log("Mined a block on the GPU, nonce: " +
+            mineParallel(128, 6000, 12345) + " (time: " +
+            (Date.now() - t) / 1000 + "s)");
 
 // Note: on the GPU, mod(a*b, c) fails when `a`
 // and `b` are big. I couldn't test harder examples


### PR DESCRIPTION
Addresses MaiaVictor/WebMonkeys#11. Results:
```
Mined a block on the CPU, nonce: 695822 (time: 0.011s)
Mined a block on the GPU, nonce: 695822 (time: 0.055s)
```
Is the GPU so much slower because it only stops after all monkeys have done their thing (unlike the CPU which stops once it mines the block), or because I’m doing something inefficient in GLSL-land? (I am total n00b to GLSL.)

Feedback welcome.