### PR TITLE
Fixed typo in del-function and improved performance of get-function

### DIFF
--- a/src/WebMonkeys.js
+++ b/src/WebMonkeys.js
@@ -244,14 +244,14 @@ load(this, function (exports) {
       gl.readPixels(0, 0, array.textureSide, array.textureSide, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
 
       if (!targetArray){
-        var result = [];
+        var result = new Float32Array(array.length);
         for (var i=0, l=array.length; i<l; ++i){
           var s = pixels[i*4+3] >= 128 ? 1 : -1;
           var e = pixels[i*4+3] - (pixels[i*4+3] >= 128 ? 128 : 0) - 63;
           var m = 1 + pixels[i*4+0]/256/256/256 + pixels[i*4+1]/256/256 + pixels[i*4+2]/256;
           var n = s * Math.pow(2, e) * m;
           var z = 0.000000000000000001; // to avoid annoying floating point error for 0
-          result.push(-z < n && n < z ? 0 : n);
+	  result[i] = (-z < n && n < z ? 0 : n);
         };
         return result;
       } else {

--- a/src/WebMonkeys.js
+++ b/src/WebMonkeys.js
@@ -357,8 +357,8 @@ load(this, function (exports) {
     // *Monkeys => String -> Monkeys
     function del(name){
       var existingArray;
-      if (existingArray = arraysByName[name]){
-        delete arraysByName[name];
+      if (existingArray = arrayByName[name]){
+        delete arrayByName[name];
         arrays = arrays.filter(function(arr){
           return arr !== existingArray;
         });


### PR DESCRIPTION
The del function was broken because it referenced `arraysByName` instead of `arrayByName`.

To improve performance of the get-function I changed the implementation from ordinary arrays to typed arrays. `Float32Array` is sufficient because it isn't possible to get more precision out of a vec4.