### PR TITLE
Fixed log-implementation for GLSL float packing

### DIFF
--- a/src/WebMonkeys.js
+++ b/src/WebMonkeys.js
@@ -60,7 +60,7 @@ load(this, function (exports) {
         "  if (m<0.0) s=1.0, m=-m;",
         "  for (int i=0; i<24; ++i){",
         "    if (m>=2.0) m=m/2.0, e+=1.0;",
-        "    if (m< 1.0) m=m/2.0, e-=1.0;",
+        "    if (m< 1.0) m=m*2.0, e-=1.0;",
         "    if (m>=1.0 && m<2.0) break;",
         "  };",
         "  return vec4(",


### PR DESCRIPTION
This implementation bug fixes the problem that numbers >-1.0 && <1.0 are not retrieved correctly